### PR TITLE
Build before packing and publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "scripts": {
     "test": "ui-tester-start tests",
-    "install": "./build"
+    "prepack": "./build",
+    "prepublishOnly": "./build"
   },
   "reciperConfig": {
     "name": "Jinkela",


### PR DESCRIPTION
Build `umd.js` and `module.js` before packing and publishing, so that the two files can be available via a CDN (such as unpkg.com).